### PR TITLE
set allowUnpruned to 15GB instead of 800GB

### DIFF
--- a/scripts/services/getConfig.ts
+++ b/scripts/services/getConfig.ts
@@ -2,7 +2,7 @@ import { ConfigSpec } from "https://deno.land/x/embassyd_sdk@v0.3.4.3.0-alpha1/t
 import { compat, types as T } from "../dependencies.ts";
 
 export const getConfig: T.ExpectedExports.getConfig = async (effects) => {
-  const allowUnpruned = (await effects.diskUsage()).total > 800_000_000_000;
+  const allowUnpruned = (await effects.diskUsage()).total > 15_000_000_000;
   return compat.getConfig({
     "peer-tor-address": {
       name: "Peer Tor Address",


### PR DESCRIPTION
Hey, this allows unpruned node if available disk size is >= 15 GB instead of 800 GB. I was trying to sync a testnet node and couldn't due to having only ~50GB available.

I ran into a couple of other issues, like a different syntax for `yq` and a deprecated `deno bundle`, but I'm leaving those untouched since I don't know if they're specific to Arch Linux.