### PR TITLE
chore: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Reporting
+
+Do not disclose suspected security vulnerabilities through public issues, pull requests, discussions, or other public channels.
+
+Report vulnerabilities in this StartOS package using [GitHub private vulnerability reporting](https://github.com/remcoros/bitcoind-testnet4-startos/security/advisories/new).
+
+For bugs with no security or privacy impact, open a [regular GitHub issue](https://github.com/remcoros/bitcoind-testnet4-startos/issues/new/choose).
+
+Email reports are not monitored.
+
+Include the affected package version, potential impact, and reproduction steps or a proof of concept. Do not include real credentials, private keys, or personal data.
+
+## Scope
+
+In scope are vulnerabilities caused by code, configuration, build artifacts, or upstream integration maintained in this repository.
+
+Vulnerabilities solely in the packaged upstream application, its dependencies, or StartOS itself are out of scope and should be reported privately to the responsible project. If you are unsure whether the package causes the issue, report it here privately.
+
+## Supported Versions
+
+Security fixes are provided for the latest package release. Users should upgrade to receive them.
+
+These disclosure rules also apply to automated tools and AI agents: suspected vulnerability details and secrets must not be placed in public or committed output before coordinated disclosure.


### PR DESCRIPTION
## Summary

- add a repository security policy with private vulnerability reporting guidance
- document the security scope and supported-version policy

## Validation

- documentation-only change; no build run